### PR TITLE
Remove TabLink.componentDidmount usage to not dispatch unnecessary actions

### DIFF
--- a/src/components/TabLink.js
+++ b/src/components/TabLink.js
@@ -6,12 +6,6 @@ export const defaultActiveStyle = {
 };
 
 class TabLink extends Component {
-    componentDidMount() {
-        if (this.props.firstLink || this.props.default) {
-            this.props.handleSelect(this.props.to, this.props.namespace);
-        }
-    }
-
     render() {
         let style = { ...this.props.style };
         if (this.props.isActive) {
@@ -41,8 +35,7 @@ TabLink.propTypes = {
     handleSelect: PropTypes.func,
     isActive: PropTypes.bool,
     namespace: PropTypes.string,
-    activeStyle: PropTypes.object,
-    firstLink: PropTypes.bool
+    activeStyle: PropTypes.object
 };
 
 export default TabLink;

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -5,34 +5,52 @@ class Tabs extends Component {
         super();
 
         this.state = {
+            defaultTab: null,
             selectedTab: null
         };
     }
 
     handleSelect(tab) {
         this.setState({
+            ...this.state,
             selectedTab: tab
         });
     }
 
-    transformChildren(children, { handleSelect, selectedTab, firstLinkFound }) {
+    findDefault(children) {
+        let firstLink;
+        let firstDefaultLink;
+
+        const traverse = (child) => {
+            if (!child.props || firstDefaultLink) {
+                return;
+            }
+
+            if (child.props.to) {
+                firstLink = firstLink || child.props.to;
+                firstDefaultLink = firstDefaultLink || (child.props.default && child.props.to);
+            }
+
+            React.Children.forEach(child.props.children, traverse);
+        };
+
+        React.Children.forEach(children, traverse);
+
+        return firstDefaultLink || firstLink;
+    }
+
+    transformChildren(children, { handleSelect, selectedTab, activeLinkStyle, name }) {
         if (typeof children !== 'object') {
             return children;
         }
 
         return React.Children.map(children, (child) => {
             if (child.props && child.props.to) {
-                const { activeLinkStyle, name } = this.props;
-                const firstLink = !firstLinkFound;
-
-                firstLinkFound = true;
-
                 return React.cloneElement(child, {
                     handleSelect,
                     isActive: child.props.to === selectedTab,
                     activeStyle: activeLinkStyle,
-                    namespace: name,
-                    firstLink
+                    namespace: name
                 });
             }
 
@@ -47,7 +65,8 @@ class Tabs extends Component {
                 this.transformChildren(child.props && child.props.children, {
                     handleSelect,
                     selectedTab,
-                    firstLinkFound
+                    activeLinkStyle,
+                    name
                 })
             );
         });
@@ -55,11 +74,16 @@ class Tabs extends Component {
 
     render() {
         const handleSelect = this.props.handleSelect || this.handleSelect.bind(this);
-        const selectedTab = this.props.selectedTab || this.state.selectedTab;
+        const selectedTab = this.props.selectedTab ||
+            this.state.selectedTab ||
+            this.state.defaultTab ||
+            (this.state.defaultTab = this.findDefault(this.props.children));
 
         const children = this.transformChildren(this.props.children, {
             handleSelect,
-            selectedTab
+            selectedTab,
+            activeLinkStyle: this.props.activeLinkStyle,
+            name: this.props.name
         });
 
         return (

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -5,19 +5,21 @@ class Tabs extends Component {
         super();
 
         this.state = {
-            defaultTab: null,
             selectedTab: null
         };
     }
 
     handleSelect(tab) {
         this.setState({
-            ...this.state,
             selectedTab: tab
         });
     }
 
     findDefault(children) {
+        if (this.defaultTab) {
+            return this.defaultTab;
+        }
+
         let firstLink;
         let firstDefaultLink;
 
@@ -36,7 +38,8 @@ class Tabs extends Component {
 
         React.Children.forEach(children, traverse);
 
-        return firstDefaultLink || firstLink;
+        this.defaultTab = firstDefaultLink || firstLink;
+        return this.defaultTab;
     }
 
     transformChildren(children, { handleSelect, selectedTab, activeLinkStyle, name }) {
@@ -76,8 +79,7 @@ class Tabs extends Component {
         const handleSelect = this.props.handleSelect || this.handleSelect.bind(this);
         const selectedTab = this.props.selectedTab ||
             this.state.selectedTab ||
-            this.state.defaultTab ||
-            (this.state.defaultTab = this.findDefault(this.props.children));
+            this.findDefault(this.props.children);
 
         const children = this.transformChildren(this.props.children, {
             handleSelect,

--- a/test/Tabs.js
+++ b/test/Tabs.js
@@ -37,8 +37,7 @@ describe('Tabs component', () => {
 
         tabLinks.forEach((tabLink, index) => {
             assert.equal(tabLink.props.namespace, 'tabs');
-            assert.equal(tabLink.props.firstLink, index === 0);
-            assert.equal(tabLink.props.isActive, false);
+            assert.equal(tabLink.props.isActive, index === 0);
             assert.equal(typeof tabLink.props.activeStyle, 'undefined');
             assert.equal(typeof tabLink.props.handleSelect, 'function');
         });
@@ -158,8 +157,9 @@ describe('Tabs component', () => {
 
         const tabLinks = ReactTestUtils.scryRenderedDOMComponentsWithClass(tabs, 'tab-link');
 
-        assert.equal(tab, 'tab1');
-        assert.equal(namespace, 'tabs');
+        // handleSelect should not be called during initialization
+        assert.equal(tab, '');
+        assert.equal(namespace, '');
 
         ReactTestUtils.Simulate.click(tabLinks[1]);
 


### PR DESCRIPTION
Hi @patrik-piskay, great work!

One thing that needs improvement is the way the default tab is determined and the fact that this happens by calling `handleSelect` which would be dispatching unwanted actions if one has it bound to a redux action creator. It would not work on the server too as `componentDidMount` is not called there.

I think its best to determine the default tab by traversing the children once and use it when needed thereafter.

Please let me know what you think.