### PR TITLE
Basic renderActiveTabContentOnly support

### DIFF
--- a/src/components/TabContent.js
+++ b/src/components/TabContent.js
@@ -11,6 +11,10 @@ export const styles = {
 };
 
 class TabContent extends Component {
+    canRenderChildren () {
+        return this.props.isVisible || (!this.props.isVisible && !this.props.renderActiveTabContentOnly);
+    }
+
     render() {
         const visibleStyle = this.props.visibleStyle || {};
 
@@ -27,7 +31,9 @@ class TabContent extends Component {
                 })}
                 style={{ ...this.props.style, ...displayStyle }}
             >
-                {this.props.children}
+                {this.canRenderChildren() && (
+                  this.props.children
+                )}
             </div>
         );
     }
@@ -38,7 +44,9 @@ TabContent.propTypes = {
         PropTypes.string,
         PropTypes.number
     ]).isRequired,
-    isVisible: PropTypes.bool
+    visibleStyle: PropTypes.object,
+    isVisible: PropTypes.bool,
+    renderActiveTabContentOnly: PropTypes.bool
 };
 
 export default TabContent;

--- a/src/components/TabContent.js
+++ b/src/components/TabContent.js
@@ -8,8 +8,8 @@ export const styles = {
 };
 
 class TabContent extends Component {
-    canRenderChildren () {
-        return this.props.isVisible || (!this.props.isVisible && !this.props.renderActiveTabContentOnly);
+    canRenderChildren() {
+        return this.props.isVisible || !this.props.renderActiveTabContentOnly;
     }
 
     render() {

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -62,7 +62,8 @@ class Tabs extends Component {
             if (child.props && child.props.for) {
                 return React.cloneElement(child, {
                     isVisible: child.props.for === selectedTab,
-                    visibleStyle: visibleTabStyle
+                    visibleStyle: visibleTabStyle,
+                    renderActiveTabContentOnly: this.props.renderActiveTabContentOnly
                 });
             }
 
@@ -113,7 +114,12 @@ Tabs.propTypes = {
     handleSelect: PropTypes.func,
     selectedTab: PropTypes.string,
     activeLinkStyle: PropTypes.object,
-    visibleTabStyle: PropTypes.object
+    visibleTabStyle: PropTypes.object,
+    renderActiveTabContentOnly: PropTypes.bool
+};
+
+Tabs.defaultProps = {
+    renderActiveTabContentOnly: false
 };
 
 export default Tabs;

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -118,8 +118,4 @@ Tabs.propTypes = {
     renderActiveTabContentOnly: PropTypes.bool
 };
 
-Tabs.defaultProps = {
-    renderActiveTabContentOnly: false
-};
-
 export default Tabs;

--- a/test/Tabs.js
+++ b/test/Tabs.js
@@ -208,4 +208,36 @@ describe('Tabs component', () => {
         assert.equal(findDOMNode(tabContents[0]).style.display, 'none');
         assert.equal(findDOMNode(tabContents[1]).style.display, '');
     });
+
+    it('should render only content of active tab', () => {
+        let tabs = ReactTestUtils.renderIntoDocument(
+          <Tabs name="tabs" selectedTab="tab2" renderActiveTabContentOnly>
+              <TabLink to="tab1" />
+              <TabLink to="tab2" />
+              <TabContent for="tab1">tabcontent1</TabContent>
+              <TabContent for="tab2">tabcontent2</TabContent>
+          </Tabs>
+        );
+
+        const tabContents = ReactTestUtils.scryRenderedDOMComponentsWithClass(tabs, 'tab-content');
+
+        assert.equal(findDOMNode(tabContents[0]).textContent, '');
+        assert.equal(findDOMNode(tabContents[1]).textContent, 'tabcontent2');
+    });
+
+    it('should render content of all tab, not just the active one', () => {
+        let tabs = ReactTestUtils.renderIntoDocument(
+          <Tabs name="tabs" selectedTab="tab2">
+              <TabLink to="tab1" />
+              <TabLink to="tab2" />
+              <TabContent for="tab1">tabcontent1</TabContent>
+              <TabContent for="tab2">tabcontent2</TabContent>
+          </Tabs>
+        );
+
+        const tabContents = ReactTestUtils.scryRenderedDOMComponentsWithClass(tabs, 'tab-content');
+
+        assert.equal(findDOMNode(tabContents[0]).textContent, 'tabcontent1');
+        assert.equal(findDOMNode(tabContents[1]).textContent, 'tabcontent2');
+    });
 });


### PR DESCRIPTION
I have created pull request for Issue #7 . There is currently no test coverage for it. In first implementation I have used [context](https://facebook.github.io/react/docs/context.html) to pass the `renderActiveTabContentOnly` into TabContent, but that did not agree with the current tests, where TabContent is tested outside of Tabs component, as a standalone component. What do you think about context vs classic property passing ? I guess TabContent and Tab could be tightly coupled, but this a matter of subjective opinion.

Let me know what you think about the pull request. Then I can continue writing the tests.
