### PR TITLE
fix for Unknown prop `renderActiveTabContentOnly` on <div> tag

### DIFF
--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -90,6 +90,7 @@ class Tabs extends Component {
             activeLinkStyle,
             visibleTabStyle,
             name,
+            renderActiveTabContentOnly,
             ...divProps
         } = this.props;
         const handleSelect = handleSelectProp || this.handleSelect;

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -90,7 +90,7 @@ class Tabs extends Component {
             activeLinkStyle,
             visibleTabStyle,
             name,
-            renderActiveTabContentOnly,
+            renderActiveTabContentOnly, // eslint-disable-line
             ...divProps
         } = this.props;
         const handleSelect = handleSelectProp || this.handleSelect;


### PR DESCRIPTION
When using renderActiveTabContentOnly the following warning is issued:

Warning: Unknown prop `renderActiveTabContentOnly` on <div> tag. Remove this prop from the element.

    in div (created by Tabs)

This pull request fixes that