### PR TITLE
Fixes bug where AMD / commonjs loader doesn't work properly when usin…

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,11 @@ var config = {
 
     externals: {
         // Use external version of React
-        react: 'React'
+        react: {
+            commonjs: "react",
+            amd: "react",
+            root: "React" // indicates global variable
+        }
     },
 
     module: {


### PR DESCRIPTION
…g dist file

Fixing a bug where AMD loaders expect 'React', when really they should be loading 'react'.

The only time we want 'React' is when we expect it to be in the global namespace ( e.g. when including a script tag )