### PR TITLE
Use "prop-types" package instead of deprecated React.PropTypes (updated)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react": "^0.14.5 || ^15.0"
   },
   "dependencies": {
-    "classnames": "^2.2.3"
+    "classnames": "^2.2.3",
+    "prop-types": "^15.5.7"
   }
 }

--- a/src/components/TabContent.js
+++ b/src/components/TabContent.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 export const styles = {

--- a/src/components/TabLink.js
+++ b/src/components/TabLink.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 export const defaultActiveStyle = {

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Tabs extends Component {
     constructor() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,12 @@ var config = {
             commonjs2: 'react',
             amd: 'react',
             root: 'React' // indicates global variable
+        },
+        'prop-types': {
+            commonjs: 'prop-types',
+            commonjs2: 'prop-types',
+            amd: 'prop-types',
+            root: 'PropTypes'
         }
     },
 


### PR DESCRIPTION
As of `React.PropTypes` has been deprecated in favour of `prop-types` package, use `prop-types` package as suggested in [React docs](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes).

Update Webpack config to not include `prop-types` package in UMD build.

Supersedes #21 .
Should fix #20.