### PR TITLE
Navigating between tabs with TAB button

### DIFF
--- a/examples/plain-react/src/index.js
+++ b/examples/plain-react/src/index.js
@@ -47,21 +47,26 @@ const App = () => (
             <div className="content">
                 <TabContent for="tab1">
                     <h2>Tab1 content</h2>
+                    <input tabIndex="1" />
                     <p>
                         Lorem ipsum dolor sit amet, in vel malorum adipiscing. Duis deleniti ei cum, amet graece nec an.
                         Eu vix sumo atqui apeirian, nullam integre accusamus his at, animal feugiat in sed.
                     </p>
+                    <input tabIndex="3" />
                     <p>
                         Pro vitae percipit no. Per ignota audire no. Ex hinc mutat delicata sit, sit eu erant tempor vivendo. Ad modus nusquam recusabo sit. Per ne deserunt periculis, ad sea saepe perfecto expetendis, est nonumy contentiones voluptatibus cu.
                     </p>
+                    <input tabIndex="2" />
                 </TabContent>
                 <TabContent for="tab2">
                     <h2>Tab2 content</h2>
                     <div>¯\_(ツ)_/¯</div>
+                    <input tabIndex="5" />
                 </TabContent>
                 <TabContent for="tab3">
                     <h2>Tab3 content</h2>
                     <div>(╯°□°）╯︵ ┻━┻)</div>
+                    <input tabIndex="4" />
                 </TabContent>
             </div>
         </Tabs>
@@ -83,14 +88,17 @@ const App = () => (
                     <p>
                         Pro vitae percipit no. Per ignota audire no. Ex hinc mutat delicata sit, sit eu erant tempor vivendo. Ad modus nusquam recusabo sit. Per ne deserunt periculis, ad sea saepe perfecto expetendis, est nonumy contentiones voluptatibus cu.
                     </p>
+                    <input />
                 </TabContent>
                 <TabContent for="tab2">
                     <h2>Tab2 content</h2>
                     <div>¯\_(ツ)_/¯</div>
+                    <input />
                 </TabContent>
                 <TabContent for="tab3">
                     <h2>Tab3 content</h2>
                     <div>(╯°□°）╯︵ ┻━┻)</div>
+                    <input />
                 </TabContent>
             </div>
         </Tabs>

--- a/examples/redux/src/components/index.js
+++ b/examples/redux/src/components/index.js
@@ -51,21 +51,26 @@ const App = (props) => (
             <div className="content">
                 <TabContent for="tab1">
                     <h2>Tab1 content</h2>
+                    <input tabIndex="1" />
                     <p>
                         Lorem ipsum dolor sit amet, in vel malorum adipiscing. Duis deleniti ei cum, amet graece nec an.
                         Eu vix sumo atqui apeirian, nullam integre accusamus his at, animal feugiat in sed.
                     </p>
+                    <input tabIndex="3" />
                     <p>
                         Pro vitae percipit no. Per ignota audire no. Ex hinc mutat delicata sit, sit eu erant tempor vivendo. Ad modus nusquam recusabo sit. Per ne deserunt periculis, ad sea saepe perfecto expetendis, est nonumy contentiones voluptatibus cu.
                     </p>
+                    <input tabIndex="2" />
                 </TabContent>
                 <TabContent for="tab2">
                     <h2>Tab2 content</h2>
                     <div>¯\_(ツ)_/¯</div>
+                    <input tabIndex="5" />
                 </TabContent>
                 <TabContent for="tab3">
                     <h2>Tab3 content</h2>
                     <div>(╯°□°）╯︵ ┻━┻)</div>
+                    <input tabIndex="4" />
                 </TabContent>
             </div>
         </Tabs>
@@ -94,14 +99,17 @@ const App = (props) => (
                     <p>
                         Pro vitae percipit no. Per ignota audire no. Ex hinc mutat delicata sit, sit eu erant tempor vivendo. Ad modus nusquam recusabo sit. Per ne deserunt periculis, ad sea saepe perfecto expetendis, est nonumy contentiones voluptatibus cu.
                     </p>
+                    <input />
                 </TabContent>
                 <TabContent for="tab2">
                     <h2>Tab2 content</h2>
                     <div>¯\_(ツ)_/¯</div>
+                    <input />
                 </TabContent>
                 <TabContent for="tab3">
                     <h2>Tab3 content</h2>
                     <div>(╯°□°）╯︵ ┻━┻)</div>
+                    <input />
                 </TabContent>
             </div>
         </Tabs>

--- a/src/components/TabContent.js
+++ b/src/components/TabContent.js
@@ -4,7 +4,8 @@ import classNames from 'classnames';
 
 export const styles = {
     hidden: {
-        display: 'none'
+        height: 0,
+        overflow: 'hidden'
     }
 };
 
@@ -22,6 +23,7 @@ class TabContent extends Component {
 
         return (
             <div
+                onFocus={this.props.onFocus}
                 className={classNames({
                     [className]: true,
                     [visibleClassName]: !!this.props.isVisible
@@ -43,6 +45,7 @@ TabContent.propTypes = {
     renderActiveTabContentOnly: PropTypes.bool,
     disableInlineStyles: PropTypes.bool,
     className: PropTypes.string,
+    onFocus: PropTypes.func,
     visibleClassName: PropTypes.string
 };
 

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -68,15 +68,17 @@ class Tabs extends Component {
             }
 
             if (child.props && child.props.for) {
+                let isVisible = child.props.for === selectedTab;
+
                 return React.cloneElement(child, {
                     onFocus: (e) => {
-                        if (child.props.for !== selectedTab) {
+                        if (!isVisible) {
                             handleSelect(child.props.for, name);
                         }
                         let { onFocus = () => {} } = child.props;
                         onFocus(e);
                     },
-                    isVisible: child.props.for === selectedTab,
+                    isVisible,
                     visibleStyle: visibleTabStyle,
                     disableInlineStyles,
                     renderActiveTabContentOnly: this.props.renderActiveTabContentOnly

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -69,6 +69,13 @@ class Tabs extends Component {
 
             if (child.props && child.props.for) {
                 return React.cloneElement(child, {
+                    onFocus: (e) => {
+                        if (child.props.for !== selectedTab) {
+                            handleSelect(child.props.for, name);
+                        }
+                        let { onFocus = () => {} } = child.props;
+                        onFocus(e);
+                    },
                     isVisible: child.props.for === selectedTab,
                     visibleStyle: visibleTabStyle,
                     disableInlineStyles,


### PR DESCRIPTION
We now should be able to navigate between tabs when pressing TAB button.

It WON'T work whenever `renderActiveTabContentOnly` is enabled.

Should fix #24 