### PR TITLE
Denote default prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,12 @@ If, for performance or other reasons, you wish to render only the content of the
 
 ### `<TabLink />` props
 
-| Prop name       | Type     | Default value     | Description                                                           |
-| :-------------- | :------- | ----------------- | --------------------------------------------------------------------- |
-| component       | _string_ | "button"          | DOM element `<TabLink />` renders to.                                 |
-| className       | _string_ | "tab-link"        | Class name that's applied to <TabLink /> elements                     |
-| activeClassName | _string_ | "tab-link-active" | Class name that's applied to the <TabLink /> element when it's active |
+| Prop name       | Type      | Default value     | Description                                                           |
+| :-------------- | :-------- | ----------------- | --------------------------------------------------------------------- |
+| component       | _string_  | "button"          | DOM element `<TabLink />` renders to.                                 |
+| className       | _string_  | "tab-link"        | Class name that's applied to <TabLink /> elements                     |
+| activeClassName | _string_  | "tab-link-active" | Class name that's applied to the <TabLink /> element when it's active |
+| default         | _boolean_ |                   | Set tab as default                                                    |
 
 ### `<TabContent />` props
 

--- a/src/components/TabLink.js
+++ b/src/components/TabLink.js
@@ -81,6 +81,7 @@ TabLink.propTypes = {
   className: PropTypes.string,
   activeClassName: PropTypes.string,
   style: PropTypes.object,
+  default: PropTypes.bool
 };
 
 export default TabLink;


### PR DESCRIPTION
In `src/components/Tabs.js` there is usage of default prop of TabLink, but it is not listed in propTypes.

Also updated readme